### PR TITLE
Resolve the model path before requiring models

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -37,10 +37,11 @@ exports.register = function (server, options, next) {
   }
 
   fs.readdirSync(options.models).forEach(function (model) {
+    var modelDir = path.resolve(options.models);
     var modelName = path.basename(model).replace(path.extname(model), '');
     modelName = modelName[0].toUpperCase() + modelName.substr(1);
     bookshelf.model(modelName,
-      require(path.join(options.models, model))(baseModel, bookshelf));
+      require(path.join(modelDir, model))(baseModel, bookshelf));
   });
 
   if (options.namespace) {


### PR DESCRIPTION
If your model path is `./models` in options.models, then `path.join` will strip the leading `.`, leading to errors when the require is no longer relative (like `Error: Cannot find module 'models/user.js'`).

This PR fixes this by calling `path.resolve` before calling require to turn relative paths into absolute ones.

Here's a related link: http://stackoverflow.com/questions/23096963/node-js-path-join-removes-leading-period
