### PR TITLE
[WIP] Added glob to support wildcard model folder structure

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,26 +1,31 @@
 var fs    = require('fs');
 var Joi   = require('joi');
+var glob  = require('glob');
 var path  = require('path');
 
 exports.register = function (server, options, next) {
 
+  var bookshelf = null;
+  var modelObjects = [];
+
   var schema = {
     knex: Joi.object().required(),
-    plugins: Joi.array().includes(Joi.string()).default([]),
-    models: Joi.string().required(),
+    plugins: Joi.array().items(Joi.string()).default([]),
+    models: Joi.array().items(Joi.string()).single().required(),
     base: Joi.func().optional(),
     namespace: Joi.string().optional()
   };
 
-  try {
-    Joi.assert(options, schema, 'Invalid Configuration Object');
-  } catch (ex) {
-    return next(ex);
+  var result = Joi.validate(options, schema);
+  if (result.error) {
+    return next(result.error);
   }
+  options = result.value;
 
-  var bookshelf;
   try {
-    bookshelf = require('bookshelf')(require('knex')(options.knex));
+    var knex = require('knex')(options.knex);
+    bookshelf = require('bookshelf');
+    bookshelf = bookshelf(knex);
   } catch (ex) {
     return next(new Error('Bad Knex Options: ' + ex.toString()));
   }
@@ -36,15 +41,34 @@ exports.register = function (server, options, next) {
     baseModel = bookshelf.Model.extend({});
   }
 
-  fs.readdirSync(options.models).forEach(function (model) {
-    var modelDir = path.resolve(options.models);
-    var modelName = path.basename(model).replace(path.extname(model), '');
-    if (!/^\..*/.test(modelName)) {
-      modelName = modelName[0].toUpperCase() + modelName.substr(1);
-      bookshelf.model(modelName,
-        require(path.join(modelDir, model))(baseModel, bookshelf));
+  var gFiles = [];
+  for (var i = options.models.length - 1; i >= 0; i--) {
+    var filename = options.models[i];
+    if (!glob.hasMagic(filename)) {
+      var stats = fs.lstatSync(filename);
+      if (stats.isDirectory()) {
+        filename = path.join(filename, '*.js');
+      }
     }
-  });
+    gFiles = glob.sync(filename);
+    modelObjects = modelObjects.concat(gFiles);
+  }
+
+  for (var o = modelObjects.length - 1; o >= 0; o--) {
+    var model = modelObjects[o];
+
+    if (fs.lstatSync(model).isFile()) {
+      var modelDir = path.dirname(model);
+      var fileName = path.basename(model)
+        .replace(path.extname(model), '');
+      if (!/^\..*/.test(fileName)) {
+        var modelName = fileName[0].toUpperCase() + fileName.substr(1);
+        bookshelf.model(modelName,
+          require(path.join(modelDir, fileName))
+          (baseModel, bookshelf));
+      }
+    }
+  }
 
   if (options.namespace) {
     server.expose(options.namespace, bookshelf);

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   "homepage": "https://github.com/lob/hapi-bookshelf-models",
   "dependencies": {
     "bookshelf": "^0.9.1",
-    "joi": "^5.1.0",
+    "glob": "^5.0.15",
+    "joi": "^6.10.1",
     "knex": "^0.7.3"
   },
   "devDependencies": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -72,9 +72,213 @@ describe('bookshelf plugin', function () {
     ], function (err) {
       expect(err).to.be.undefined;
       expect(server.plugins.bookshelf.model('User')).to.be.a('function');
+      expect(server.plugins.bookshelf.model('Role')).to.be.undefined;
       var User = server.plugins.bookshelf.model('User').forge({ id: 1 });
       expect(User.test).to.eql('test');
     });
+  });
+
+  it('should load a good configuration with glob', function () {
+    var server = new Hapi.Server();
+
+    server.register([
+      {
+        register: require('../lib/'),
+        options: {
+          knex: {
+            client: 'sqlite3',
+            connection: {
+              filename: './database.sqlite'
+            }
+          },
+          plugins: ['registry'],
+          models: [
+            path.join(__dirname + '/models/*.js'),
+            path.join(__dirname + '/models/subfolder/*.js')
+          ],
+          base: function (bookshelf) {
+            return bookshelf.Model.extend({
+              test: 'test'
+            });
+          }
+        }
+      }
+    ], function (err) {
+      expect(err).to.be.undefined;
+      expect(server.plugins.bookshelf.model('User')).to.be.a('function');
+      expect(server.plugins.bookshelf.model('Role')).to.be.a('function');
+      var User = server.plugins.bookshelf.model('User').forge({ id: 1 });
+      expect(User.test).to.eql('test');
+    });
+  });
+
+  it('should load a good configuration with recursive glob as array',
+    function () {
+      var server = new Hapi.Server();
+
+      server.register([
+        {
+          register: require('../lib/'),
+          options: {
+            knex: {
+              client: 'sqlite3',
+              connection: {
+                filename: './database.sqlite'
+              }
+            },
+            plugins: ['registry'],
+            models: [path.join(__dirname + '/models/**/*.js')],
+            base: function (bookshelf) {
+              return bookshelf.Model.extend({
+                test: 'test'
+              });
+            }
+          }
+        }
+      ], function (err) {
+        expect(err).to.be.undefined;
+        expect(server.plugins.bookshelf.model('User')).to.be.a('function');
+        expect(server.plugins.bookshelf.model('Role')).to.be.a('function');
+        var User = server.plugins.bookshelf.model('User').forge({ id: 1 });
+        expect(User.test).to.eql('test');
+      }
+    );
+  });
+
+  it('should load a good configuration with recursive glob as string',
+    function () {
+      var server = new Hapi.Server();
+
+      server.register([
+        {
+          register: require('../lib/'),
+          options: {
+            knex: {
+              client: 'sqlite3',
+              connection: {
+                filename: './database.sqlite'
+              }
+            },
+            plugins: ['registry'],
+            models: path.join(__dirname + '/models/**/*.js'),
+            base: function (bookshelf) {
+              return bookshelf.Model.extend({
+                test: 'test'
+              });
+            }
+          }
+        }
+      ], function (err) {
+        expect(err).to.be.undefined;
+        expect(server.plugins.bookshelf.model('User')).to.be.a('function');
+        expect(server.plugins.bookshelf.model('Role')).to.be.a('function');
+        var User = server.plugins.bookshelf.model('User').forge({ id: 1 });
+        expect(User.test).to.eql('test');
+      }
+    );
+  });
+
+  it('should load a good configuration with absolute path as string',
+    function () {
+      var server = new Hapi.Server();
+
+      server.register([
+        {
+          register: require('../lib/'),
+          options: {
+            knex: {
+              client: 'sqlite3',
+              connection: {
+                filename: './database.sqlite'
+              }
+            },
+            plugins: ['registry'],
+            models: path.join(__dirname + '/models/user.js'),
+            base: function (bookshelf) {
+              return bookshelf.Model.extend({
+                test: 'test'
+              });
+            }
+          }
+        }
+      ], function (err) {
+        expect(err).to.be.undefined;
+        expect(server.plugins.bookshelf.model('User')).to.be.a('function');
+        var User = server.plugins.bookshelf.model('User').forge({ id: 1 });
+        expect(User.test).to.eql('test');
+      }
+    );
+  });
+
+  it('should load a good configuration with absolute paths as array',
+    function () {
+      var server = new Hapi.Server();
+
+      server.register([
+        {
+          register: require('../lib/'),
+          options: {
+            knex: {
+              client: 'sqlite3',
+              connection: {
+                filename: './database.sqlite'
+              }
+            },
+            plugins: ['registry'],
+            models: [
+              path.join(__dirname + '/models/user.js'),
+              path.join(__dirname + '/models/subfolder/role.js')
+            ],
+            base: function (bookshelf) {
+              return bookshelf.Model.extend({
+                test: 'test'
+              });
+            }
+          }
+        }
+      ], function (err) {
+        expect(err).to.be.undefined;
+        expect(server.plugins.bookshelf.model('User')).to.be.a('function');
+        expect(server.plugins.bookshelf.model('Role')).to.be.a('function');
+        var User = server.plugins.bookshelf.model('User').forge({ id: 1 });
+        expect(User.test).to.eql('test');
+      }
+    );
+  });
+
+  it('should load combination of models',
+    function () {
+      var server = new Hapi.Server();
+      var _baseOptions = {
+        register: require('../lib/'),
+        options: {
+          knex: {
+            client: 'sqlite3',
+            connection: {
+              filename: './database.sqlite'
+            }
+          },
+          plugins: ['registry'],
+          base: function (bookshelf) {
+            return bookshelf.Model.extend({
+              test: 'test'
+            });
+          }
+        }
+      };
+
+      _baseOptions.options.models = [
+        path.join(__dirname + '/models/user.js'),
+        path.join(__dirname + '/models/subfolder/**/*.js')
+      ];
+      server.register([_baseOptions], function (err) {
+        expect(err).to.be.undefined;
+        expect(server.plugins.bookshelf.model('User')).to.be.a('function');
+        expect(server.plugins.bookshelf.model('Role')).to.be.a('function');
+        var User = server.plugins.bookshelf.model('User').forge({ id: 1 });
+        expect(User.test).to.eql('test');
+      });
+
   });
 
   it('should load a good configuration without base', function () {

--- a/test/models/subfolder/role.js
+++ b/test/models/subfolder/role.js
@@ -1,0 +1,5 @@
+module.exports = function (bookshelf) {
+  return bookshelf.extend({
+    tableName: 'roles'
+  });
+};


### PR DESCRIPTION
I tried to use hapi-bookshelf-models in my hapi application but with the lack of support of multidimensional folder structure for the models and wildcard model name definition there would was no reason for me to use this library.
With these changes you'll be able to use hapi-bookshelf-models as you know it or with support of an options.models array/string using glob syntax.

If there is anything wrong inside the code or opportunities for improvement, please let me know and i'll fix it.
