### PR TITLE
Upgrade bookshelf to 0.9.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/lob/hapi-bookshelf-models",
   "dependencies": {
-    "bookshelf": "^0.7.9",
+    "bookshelf": "^0.9.1",
     "joi": "^5.1.0",
     "knex": "^0.7.3"
   },


### PR DESCRIPTION
[Changelog is here](https://github.com/tgriesser/bookshelf/blob/e58b5fc0645febc314d4a932defe772e15d5e748/CHANGELOG.md)

There was a small breaking change from 0.7.9 -> 0.9.1, but according to the Changelog it wouldn't affect very many people. I'll leave it up to the maintainers here to decide whether this package should receive a major version bump.
