### PR TITLE
Add Collection Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,11 @@ server.register([
       },
       plugins: ['registry'], // Required
       models: '../path/to/models/directory',
-      base: require('../path/to/model/base') // optional
+      collections: '../path/to/collections/directory',
+      base: {
+        model: require('../path/to/model/base'), // optional
+        collection: require('../path/to/collection/base') // optional
+      }
     }
   }
 ], function (err) {
@@ -105,8 +109,8 @@ server.register([
   {
     register: require('hapi-bookshelf-models'),
     options: {
-      knex: { 
-        //connection two details 
+      knex: {
+        //connection two details
       },
       plugins: ['registry'],
       models: '../path/to/namespacetwo/models/directory',

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,13 +6,16 @@ var path  = require('path');
 exports.register = function (server, options, next) {
 
   var bookshelf = null;
-  var modelObjects = [];
 
   var schema = {
     knex: Joi.object().required(),
     plugins: Joi.array().items(Joi.string()).default([]),
-    models: Joi.array().items(Joi.string()).single().required(),
-    base: Joi.func().optional(),
+    models: Joi.array().items(Joi.string()).single().default([]),
+    collections: Joi.array().items(Joi.string()).single().default([]),
+    base: Joi.alternatives().try(Joi.func(), Joi.object({
+      model: Joi.func().optional(),
+      collection: Joi.func().optional()
+    })).optional(),
     namespace: Joi.string().optional()
   };
 
@@ -35,41 +38,63 @@ exports.register = function (server, options, next) {
   });
 
   var baseModel;
+  var baseCollection;
   if (options.base) {
-    baseModel = options.base(bookshelf);
-  } else {
+    if (typeof options.base === 'function') {
+      baseModel = options.base(bookshelf);
+    } else {
+      if (options.base.model) {
+        baseModel = options.base.model(bookshelf);
+      }
+      if (options.base.collection) {
+        baseCollection = options.base.collection(bookshelf);
+      }
+    }
+  }
+
+  if (!baseModel) {
     baseModel = bookshelf.Model.extend({});
   }
-
-  var gFiles = [];
-  for (var i = options.models.length - 1; i >= 0; i--) {
-    var filename = options.models[i];
-    if (!glob.hasMagic(filename)) {
-      filename = path.resolve(filename);
-      var stats = fs.lstatSync(filename);
-      if (stats.isDirectory()) {
-        filename = path.join(filename, '*.js');
-      }
-    }
-    gFiles = glob.sync(filename);
-    modelObjects = modelObjects.concat(gFiles);
+  if (!baseCollection) {
+    baseCollection = bookshelf.Collection.extend({});
   }
 
-  for (var o = modelObjects.length - 1; o >= 0; o--) {
-    var model = modelObjects[o];
+  function load (type, globPaths) {
+    var base = type === 'model' ? baseModel : baseCollection;
+    var gFiles = [];
+    var modelObjects = [];
+    for (var i = globPaths.length - 1; i >= 0; i--) {
+      var filename = globPaths[i];
+      if (!glob.hasMagic(filename)) {
+        filename = path.resolve(filename);
+        var stats = fs.lstatSync(filename);
+        if (stats.isDirectory()) {
+          filename = path.join(filename, '*.js');
+        }
+      }
+      gFiles = glob.sync(filename);
+      modelObjects = modelObjects.concat(gFiles);
+    }
 
-    if (fs.lstatSync(model).isFile()) {
-      var modelDir = path.dirname(model);
-      var fileName = path.basename(model)
-        .replace(path.extname(model), '');
-      if (!/^\..*/.test(fileName)) {
-        var modelName = fileName[0].toUpperCase() + fileName.substr(1);
-        bookshelf.model(modelName,
-          require(path.resolve(path.join(modelDir, fileName)))
-          (baseModel, bookshelf));
+    for (var o = modelObjects.length - 1; o >= 0; o--) {
+      var model = modelObjects[o];
+
+      if (fs.lstatSync(model).isFile()) {
+        var modelDir = path.dirname(model);
+        var fileName = path.basename(model)
+          .replace(path.extname(model), '');
+        if (!/^\..*/.test(fileName)) {
+          var modelPath = path.resolve(path.join(modelDir, fileName));
+          var modelName = fileName[0].toUpperCase() + fileName.substr(1);
+          var modelDef = require(modelPath)(base, bookshelf);
+          bookshelf[type](modelName, modelDef);
+        }
       }
     }
   }
+
+  load('model', options.models);
+  load('collection', options.collections);
 
   if (options.namespace) {
     server.expose(options.namespace, bookshelf);

--- a/test/collections/users.js
+++ b/test/collections/users.js
@@ -1,0 +1,5 @@
+module.exports = function (baseCollection, bookshelf) {
+  return baseCollection.extend({
+    model: bookshelf.model('User')
+  });
+};

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -358,4 +358,71 @@ describe('bookshelf plugin', function () {
       expect(server.plugins.bookshelf.test.model('User')).to.be.a('function');
     });
   });
+
+  it('should load a good configuration with base object', function () {
+    var server = new Hapi.Server();
+
+    server.register([
+      {
+        register: require('../lib/'),
+        options: {
+          knex: {
+            client: 'sqlite3',
+            connection: {
+              filename: './database.sqlite'
+            }
+          },
+          plugins: ['registry'],
+          models: path.join(__dirname + '/models'),
+          base: {
+            model: function (bookshelf) {
+              return bookshelf.Model.extend({
+                test: 'test'
+              });
+            }
+          }
+        }
+      }
+    ], function (err) {
+      expect(err).to.be.undefined;
+      expect(server.plugins.bookshelf.model('User')).to.be.a('function');
+      var User = server.plugins.bookshelf.model('User').forge({ id: 1 });
+      expect(User.test).to.eql('test');
+    });
+  });
+
+  it('should load a good configuration with base collection', function () {
+    var server = new Hapi.Server();
+
+    server.register([
+      {
+        register: require('../lib/'),
+        options: {
+          knex: {
+            client: 'sqlite3',
+            connection: {
+              filename: './database.sqlite'
+            }
+          },
+          plugins: ['registry'],
+          models: path.join(__dirname + '/models'),
+          collections: path.join(__dirname + '/collections'),
+          base: {
+            collection: function (bookshelf) {
+              return bookshelf.Collection.extend({
+                test: 'test'
+              });
+            }
+          }
+        }
+      }
+    ], function (err) {
+      expect(err).to.be.undefined;
+      expect(server.plugins.bookshelf.model('User')).to.be.a('function');
+      expect(server.plugins.bookshelf.collection('Users')).to.be.a('function');
+      var User = server.plugins.bookshelf.model('User').forge({ id: 1 });
+      var Users = server.plugins.bookshelf.collection('Users').forge([User]);
+      expect(Users.test).to.eql('test');
+    });
+  });
 });


### PR DESCRIPTION
Hi!

This PR adds support for `collection` loading to the plugin. It adds an optional `collections` option for locating `collection` files. It also overloads the `base` option to _alternatively_ take an object instead of a function to support a base collection as well as a base model.

```
base: {
  model: require('../path/to/model/base'), // optional
  collection: require('../path/to/collection/base') // optional
}
```

It is important to note that this addition **does not break backwards compatibility** with the existing plugin. 
