### PR TITLE
Set knex and bookshelf as peerDependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
 - '0.10.32'
+before_script:
+- npm i knex@0 bookshelf@0
 after_script:
 - npm run enforce
 - npm run coveralls

--- a/lib/index.js
+++ b/lib/index.js
@@ -93,8 +93,12 @@ exports.register = function (server, options, next) {
     }
   }
 
-  load('model', options.models);
-  load('collection', options.collections);
+  try {
+    load('model', options.models);
+    load('collection', options.collections);
+  } catch (ex) {
+    return next(new Error('Bad model/collection Options: ' + ex.toString()));
+  }
 
   if (options.namespace) {
     server.expose(options.namespace, bookshelf);

--- a/package.json
+++ b/package.json
@@ -26,10 +26,12 @@
   },
   "homepage": "https://github.com/lob/hapi-bookshelf-models",
   "dependencies": {
-    "bookshelf": "^0.9.1",
     "glob": "^5.0.15",
-    "joi": "^6.10.1",
-    "knex": "^0.7.3"
+    "joi": "^6.10.1"
+  },
+  "peerDependencies": {
+    "bookshelf": "0.x",
+    "knex": "0.x"
   },
   "devDependencies": {
     "chai": "^1.10.0",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -4,7 +4,28 @@ var Hapi    = require('hapi');
 var path    = require('path');
 
 describe('bookshelf plugin', function () {
-  it('should fail to load with bad knex', function () {
+  it('should fail to load with bad knex options', function () {
+    var server = new Hapi.Server();
+
+    server.register([
+      {
+        register: require('../lib/'),
+        options: {
+          knex: {
+            client: 'fake_client'
+          },
+          models: 'asdf',
+          base: function () {
+            return 1;
+          }
+        }
+      }
+    ], function (err) {
+      expect(err).to.be.instanceof(Error);
+    });
+  });
+
+  it('should fail to load with bad models path', function () {
     var server = new Hapi.Server();
 
     server.register([
@@ -56,6 +77,7 @@ describe('bookshelf plugin', function () {
         options: {
           knex: {
             client: 'sqlite3',
+            useNullAsDefault: true,
             connection: {
               filename: './database.sqlite'
             }
@@ -87,6 +109,7 @@ describe('bookshelf plugin', function () {
         options: {
           knex: {
             client: 'sqlite3',
+            useNullAsDefault: true,
             connection: {
               filename: './database.sqlite'
             }
@@ -118,6 +141,7 @@ describe('bookshelf plugin', function () {
         options: {
           knex: {
             client: 'sqlite3',
+            useNullAsDefault: true,
             connection: {
               filename: './database.sqlite'
             }
@@ -153,6 +177,7 @@ describe('bookshelf plugin', function () {
           options: {
             knex: {
               client: 'sqlite3',
+              useNullAsDefault: true,
               connection: {
                 filename: './database.sqlite'
               }
@@ -186,6 +211,7 @@ describe('bookshelf plugin', function () {
           options: {
             knex: {
               client: 'sqlite3',
+              useNullAsDefault: true,
               connection: {
                 filename: './database.sqlite'
               }
@@ -219,6 +245,7 @@ describe('bookshelf plugin', function () {
           options: {
             knex: {
               client: 'sqlite3',
+              useNullAsDefault: true,
               connection: {
                 filename: './database.sqlite'
               }
@@ -251,6 +278,7 @@ describe('bookshelf plugin', function () {
           options: {
             knex: {
               client: 'sqlite3',
+              useNullAsDefault: true,
               connection: {
                 filename: './database.sqlite'
               }
@@ -285,6 +313,7 @@ describe('bookshelf plugin', function () {
         options: {
           knex: {
             client: 'sqlite3',
+            useNullAsDefault: true,
             connection: {
               filename: './database.sqlite'
             }
@@ -321,6 +350,7 @@ describe('bookshelf plugin', function () {
         options: {
           knex: {
             client: 'sqlite3',
+            useNullAsDefault: true,
             connection: {
               filename: './database.sqlite'
             }
@@ -344,6 +374,7 @@ describe('bookshelf plugin', function () {
         options: {
           knex: {
             client: 'sqlite3',
+            useNullAsDefault: true,
             connection: {
               filename: './database.sqlite'
             }
@@ -368,6 +399,7 @@ describe('bookshelf plugin', function () {
         options: {
           knex: {
             client: 'sqlite3',
+            useNullAsDefault: true,
             connection: {
               filename: './database.sqlite'
             }
@@ -400,6 +432,7 @@ describe('bookshelf plugin', function () {
         options: {
           knex: {
             client: 'sqlite3',
+            useNullAsDefault: true,
             connection: {
               filename: './database.sqlite'
             }


### PR DESCRIPTION
Empty knex configuration options no longer error, so I updated the first test to instead check for invalid models/collections paths which do error.

This update brings knex to the latest version which includes nice features such as varbinary columns in mysql.
