### PR TITLE
chore(errors): report original error if models/collections fail

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -32,7 +32,7 @@ exports.register = function (server, options, next) {
     bookshelf = require('bookshelf');
     bookshelf = bookshelf(knex);
   } catch (ex) {
-    return next(new Error('Bad Knex Options: ' + ex.toString()));
+    return next(ex);
   }
 
   options.plugins.map(function (plugin) {
@@ -93,7 +93,7 @@ exports.register = function (server, options, next) {
     load('model', options.models);
     load('collection', options.collections);
   } catch (ex) {
-    return next(new Error('Bad model/collection Options: ' + ex.toString()));
+    return next(ex);
   }
 
   if (options.namespace) {


### PR DESCRIPTION
Previously, syntax errors in models/collections would report like this:

```
/Users/username/app/index.js:123
  if (errRegister) throw errRegister;
                   ^

Error: Bad model/collection Options: SyntaxError: Unexpected token {
    at Object.exports.register (/Users/username/node_modules/hapi-bookshelf-models/lib/index.js:100:17)
    at Object.target [as register] (/Users/username/node_modules/hapi/node_modules/joi/lib/object.js:79:30)
    at each (/Users/username/node_modules/hapi/lib/plugin.js:317:14)
    at iterate (/Users/username/node_modules/hapi/node_modules/items/lib/index.js:36:13)
    at done (/Users/username/node_modules/hapi/node_modules/items/lib/index.js:28:25)
    at Object.exports.register (/Users/username/node_modules/hapi-api-version/index.js:101:12)
```

which is not all that useful for finding which file has the error, especially when there are lots of models. A much better error message would be:

```
/Users/username/app/models/playback.js:12
  }, {
     ^
SyntaxError: Unexpected token {
    at exports.runInThisContext (vm.js:53:16)
    at Module._compile (module.js:511:25)
    at Object.Module._extensions..js (module.js:550:10)
    at Module.load (module.js:456:32)
    at tryModuleLoad (module.js:415:12)
    at Function.Module._load (module.js:407:3)
    at Module.require (module.js:466:17)
    at require (internal/module.js:20:19)
    at load (/Users/username/node_modules/hapi-bookshelf-models/lib/index.js:89:26)
    at Object.exports.register (/Users/username/node_modules/hapi-bookshelf-models/lib/index.js:97:5)
    at Object.target [as register] (/Users/username/node_modules/hapi/node_modules/joi/lib/object.js:79:30)
    at each (/Users/username/node_modules/hapi/lib/plugin.js:317:14)
```

which is what gets outputted by this PR.
